### PR TITLE
fix last version of status page

### DIFF
--- a/src/pages/StatusPage/SuccessView.tsx
+++ b/src/pages/StatusPage/SuccessView.tsx
@@ -83,14 +83,15 @@ export const SuccessView = ({ status }) => {
           <Barcode size={50} />
         )}
         <StatusTitle fontSize="26px">
-          {status?.product_type + " " + status?.product?.name}{" "}
+          {status?.productType + " " + status?.product?.name}
+          {" - "}
           {isStatusCompleted &&
-            status?.fiat_unit_price + "" + status?.fiat_currency}
+            status?.fiatUnitPrice + "" + status?.fiatCurrency}
         </StatusTitle>
         <StatusSubtitle fontSize="18px">
           {t("success.message.notification", {
-            productType: status?.product_type || "item",
-            reference: status?.given_reference || "your reference",
+            productType: status?.productType || "item",
+            reference: status?.givenReference || "your reference",
           })}
         </StatusSubtitle>
       </ProductBox>


### PR DESCRIPTION
## Description
<img width="420" alt="Screenshot 2025-02-05 at 9 51 18 PM" src="https://github.com/user-attachments/assets/69e1d493-06f8-4965-ba88-9a9d7f5807c8" />
<img width="417" alt="Screenshot 2025-02-05 at 9 54 05 PM" src="https://github.com/user-attachments/assets/a496d869-1c78-4b37-bb50-b3f399391b31" />

### NOTES 
 All the undefined and default names on SS are before updating API names, after the current changes that will be solved
