### PR TITLE
CHORE - Support and Add funds deep link on the mini app pt1: Emit events from widget.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13-beta.9](https://github.com/bandohq/widget/compare/v0.1.13-beta.8...v0.1.13-beta.9) (2025-02-07)
+
 ### [0.1.13-beta.8](https://github.com/bandohq/widget/compare/v0.1.13-beta.7...v0.1.13-beta.8) (2025-02-07)
 
 ### [0.1.13-beta.7](https://github.com/bandohq/widget/compare/v0.1.13-beta.6...v0.1.13-beta.7) (2025-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13-beta.8](https://github.com/bandohq/widget/compare/v0.1.13-beta.7...v0.1.13-beta.8) (2025-02-07)
+
 ### [0.1.13-beta.7](https://github.com/bandohq/widget/compare/v0.1.13-beta.6...v0.1.13-beta.7) (2025-02-07)
 
 ### [0.1.13-beta.6](https://github.com/bandohq/widget/compare/v0.1.13-beta.5...v0.1.13-beta.6) (2025-02-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13-beta.7](https://github.com/bandohq/widget/compare/v0.1.13-beta.6...v0.1.13-beta.7) (2025-02-07)
+
 ### [0.1.13-beta.6](https://github.com/bandohq/widget/compare/v0.1.13-beta.5...v0.1.13-beta.6) (2025-02-07)
 
 ### [0.1.13-beta.5](https://github.com/bandohq/widget/compare/v0.1.13-beta.3...v0.1.13-beta.5) (2025-02-07)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.6",
+  "version": "0.1.13-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bandohq/widget",
-      "version": "0.1.13-beta.6",
+      "version": "0.1.13-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@bandohq/contract-abis": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.7",
+  "version": "0.1.13-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bandohq/widget",
-      "version": "0.1.13-beta.7",
+      "version": "0.1.13-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@bandohq/contract-abis": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.8",
+  "version": "0.1.13-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bandohq/widget",
-      "version": "0.1.13-beta.8",
+      "version": "0.1.13-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@bandohq/contract-abis": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.7",
+  "version": "0.1.13-beta.8",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.6",
+  "version": "0.1.13-beta.7",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.8",
+  "version": "0.1.13-beta.9",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/components/SelectTokenButton/SelectTokenButtonForProducts.tsx
+++ b/src/components/SelectTokenButton/SelectTokenButtonForProducts.tsx
@@ -8,6 +8,7 @@ import { useFieldValues } from "../../stores/form/useFieldValues.js";
 import { navigationRoutes } from "../../utils/navigationRoutes.js";
 import { AvatarBadgedDefault, AvatarBadgedSkeleton } from "../Avatar/Avatar";
 import { CardTitle } from "../Card/CardTitle";
+import { useWidgetEvents } from "../../hooks/useWidgetEvents.js";
 import {
   CardContent,
   SelectTokenCard,
@@ -20,6 +21,7 @@ import { Avatar, Skeleton } from "@mui/material";
 import { CaretDown } from "@phosphor-icons/react";
 import { useQuotes } from "../../providers/QuotesProvider/QuotesProvider.js";
 import { Box } from "@mui/material";
+import { WidgetEvent, InsufficientBalance } from "../../types/events.js";
 
 export const SelectTokenButtonForProducts: React.FC<
   FormTypeProps & {
@@ -29,6 +31,7 @@ export const SelectTokenButtonForProducts: React.FC<
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { product } = useProduct();
+  const emitter = useWidgetEvents();
   const {
     quote,
     isPending: quotePending,
@@ -56,6 +59,28 @@ export const SelectTokenButtonForProducts: React.FC<
   const handleClick = () => {
     navigate(navigationRoutes.fromToken);
   };
+
+  const renderWarning = () => {
+    if (quote?.total_amount && !isPurchasePossible) {
+      emitter.emit(
+        WidgetEvent.InsufficientBalance,
+        { chainId: chainId, tokenAddress: tokenAddress } as InsufficientBalance
+      );
+      return (
+        <Box
+          sx={{
+            color: "red",
+            display: "flex",
+            justifyContent: "center",
+            padding: "5px",
+            textAlign: "right",
+          }}
+        >
+          {t("warning.message.insufficientFunds")}
+        </Box>
+      );
+    }
+  }
 
   const isSelected = !!(chain && token);
   const defaultPlaceholder = !account.isConnected
@@ -148,6 +173,7 @@ export const SelectTokenButtonForProducts: React.FC<
           />
         )}
       </CardContent>
+      {renderWarning()}
       {quote?.total_amount && !isPurchasePossible && (
         <Box
           sx={{

--- a/src/components/TokenList/TokenNotFound.tsx
+++ b/src/components/TokenList/TokenNotFound.tsx
@@ -4,12 +4,19 @@ import type { FormTypeProps } from '../../stores/form/types.js'
 import { FormKeyHelper } from '../../stores/form/types.js'
 import { useFieldValues } from '../../stores/form/useFieldValues.js'
 import { SearchNotFound } from '../Search/SearchNotFound.js'
+import { useWidgetEvents } from '../../hooks/useWidgetEvents.js'
+import { WidgetEvent, NoTokensAvailable } from '../../types/events.js'
 
 export const TokenNotFound: React.FC<FormTypeProps> = ({ formType }) => {
   const { t } = useTranslation()
   const [selectedChainId] = useFieldValues(FormKeyHelper.getChainKey(formType))
+  const emitter = useWidgetEvents()
   const { getChainById } = useAvailableChains()
 
+  emitter.emit(WidgetEvent.NoTokensAvailable, {
+    chainId: selectedChainId,
+  } as NoTokensAvailable)
+  
   return (
     <SearchNotFound
       message={t('info.message.emptyTokenList', {

--- a/src/components/TokenList/TokenNotFound.tsx
+++ b/src/components/TokenList/TokenNotFound.tsx
@@ -6,6 +6,7 @@ import { useFieldValues } from '../../stores/form/useFieldValues.js'
 import { SearchNotFound } from '../Search/SearchNotFound.js'
 import { useWidgetEvents } from '../../hooks/useWidgetEvents.js'
 import { WidgetEvent, NoTokensAvailable } from '../../types/events.js'
+import { useEffect } from 'react'
 
 export const TokenNotFound: React.FC<FormTypeProps> = ({ formType }) => {
   const { t } = useTranslation()
@@ -13,9 +14,11 @@ export const TokenNotFound: React.FC<FormTypeProps> = ({ formType }) => {
   const emitter = useWidgetEvents()
   const { getChainById } = useAvailableChains()
 
-  emitter.emit(WidgetEvent.NoTokensAvailable, {
-    chainId: selectedChainId,
-  } as NoTokensAvailable)
+  useEffect(() => {
+    emitter.emit(WidgetEvent.NoTokensAvailable, {
+      chainId: selectedChainId,
+    } as NoTokensAvailable)
+  }, [emitter, selectedChainId]);
   
   return (
     <SearchNotFound

--- a/src/components/TokenList/useTokenSelect.ts
+++ b/src/components/TokenList/useTokenSelect.ts
@@ -33,10 +33,7 @@ export const useTokenSelect = (formType: FormType, onClick?: () => void) => {
         isTouched: true,
       })
 
-      const eventToEmit =
-        formType === 'from'
-          ? WidgetEvent.SourceChainTokenSelected
-          : WidgetEvent.DestinationChainTokenSelected
+      const eventToEmit = WidgetEvent.SourceChainTokenSelected
 
       if (selectedChainId) {
         emitter.emit(eventToEmit, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import "react-phone-number-input/style.css"
 export { App as BandoWidget } from './App'
 export { useWallets, walletComparator } from './hooks/useWallets';
+export { useWidgetEvents, widgetEvents } from './hooks/useWidgetEvents.js'
 export * from './config/versions.js'
 export * from './types/widget.js'
 export * from './types/events.js'

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -10,15 +10,8 @@ export type NavigationRouteType = string; // Simulates NavigationRouteType
 
 // Keep the enum and events as they were
 export enum WidgetEvent {
-  RouteExecutionStarted = 'routeExecutionStarted',
-  RouteExecutionUpdated = 'routeExecutionUpdated',
-  RouteExecutionCompleted = 'routeExecutionCompleted',
-  RouteExecutionFailed = 'routeExecutionFailed',
-  RouteHighValueLoss = 'routeHighValueLoss',
-  AvailableRoutes = 'availableRoutes',
   ContactSupport = 'contactSupport',
   SourceChainTokenSelected = 'sourceChainTokenSelected',
-  DestinationChainTokenSelected = 'destinationChainTokenSelected',
   QuoteFetched = 'quoteFetched',
   /**
    * @deprecated Use `PageEntered` event instead.
@@ -29,25 +22,22 @@ export enum WidgetEvent {
   PageEntered = 'pageEntered',
   FormFieldChanged = 'formFieldChanged',
   SettingUpdated = 'settingUpdated',
+  NoTokensAvailable = 'noTokensAvailable',
+  InsufficientBalance = 'insufficientBalance',
 }
 
 // Mocking the widget events type
 export type WidgetEvents = {
-  routeExecutionStarted: Route;
-  routeExecutionUpdated: RouteExecutionUpdate;
-  routeExecutionCompleted: Route;
-  routeExecutionFailed: RouteExecutionUpdate;
-  routeHighValueLoss: RouteHighValueLossUpdate;
-  availableRoutes: Route[];
   contactSupport: ContactSupport;
   sourceChainTokenSelected: ChainTokenSelected;
-  destinationChainTokenSelected: ChainTokenSelected;
   formFieldChanged: FormFieldChanged;
   reviewTransactionPageEntered?: Route;
   walletConnected: WalletConnected;
   widgetExpanded: boolean;
   pageEntered: NavigationRouteType;
   settingUpdated: SettingUpdated;
+  noTokensAvailable: NoTokensAvailable;
+  insufficientBalance: InsufficientBalance;
 };
 
 // Mocking the interfaces
@@ -55,20 +45,16 @@ export interface ContactSupport {
   supportId?: string;
 }
 
-export interface RouteHighValueLossUpdate {
-  fromAmountUSD: number;
-  toAmountUSD: number;
-  gasCostUSD?: number;
-  feeCostUSD?: number;
-  valueLoss: number;
-}
-
-export interface RouteExecutionUpdate {
-  route: Route;
-  process: Process;
-}
-
 export interface ChainTokenSelected {
+  chainId: ChainId;
+  tokenAddress: string;
+}
+
+export interface NoTokensAvailable {
+  chainId: ChainId;
+}
+
+export interface InsufficientBalance {
   chainId: ChainId;
   tokenAddress: string;
 }


### PR DESCRIPTION
- **emit event when insufficient funds or no tokens ar found**
- **chore(release): 0.1.13-beta.7**

## Description

Emits events when there are insufficient funds on the selected token or there are no balance on any tokens in the connected chain.

This is useful because we need to detect these cases on the minipay app to prompt the user to fund their minipay wallet using their deep link.

### Where to test
Install the 0.1.13-beta.7 version on any app and test the events mentioned.

