### PR TITLE
CHORE - Ability to hide the header and settings from the widget config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13-beta.20](https://github.com/bandohq/widget/compare/v0.1.13-beta.19...v0.1.13-beta.20) (2025-02-26)
+
+### [0.1.13-beta.18](https://github.com/bandohq/widget/compare/v0.1.13-beta.17...v0.1.13-beta.18) (2025-02-25)
+
 ### [0.1.13-beta.19](https://github.com/bandohq/widget/compare/v0.1.13-beta.17...v0.1.13-beta.19) (2025-02-26)
 
 ### [0.1.13-beta.17](https://github.com/bandohq/widget/compare/v0.1.13-beta.16...v0.1.13-beta.17) (2025-02-21)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.19",
+  "version": "0.1.13-beta.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bandohq/widget",
-      "version": "0.1.13-beta.19",
+      "version": "0.1.13-beta.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@bandohq/contract-abis": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.19",
+  "version": "0.1.13-beta.20",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/components/Header/NavigationHeader.tsx
+++ b/src/components/Header/NavigationHeader.tsx
@@ -35,10 +35,11 @@ export const NavigationHeader: React.FC = () => {
 
   return (
     <>
-      <HeaderAppBar elevation={0}>
-        {isBackButtonVisible ? <BackButton onClick={navigateBack} /> : null}
-        {splitSubvariant ? (
-          <Box flex={1}>
+      {(isBackButtonVisible || !hiddenUI?.includes(HiddenUI.Header)) && (
+        <HeaderAppBar elevation={0}>
+          {isBackButtonVisible ? <BackButton onClick={navigateBack} /> : null}
+          {splitSubvariant ? (
+            <Box flex={1}>
             <SplitWalletMenuButton />
           </Box>
         ) : (
@@ -57,7 +58,7 @@ export const NavigationHeader: React.FC = () => {
             path={navigationRoutes.home}
             element={
               <HeaderControlsContainer>
-                <SettingsButton />
+                {!hiddenUI?.includes(HiddenUI.Header) && <SettingsButton />}
                 {variant === "drawer" &&
                 !hiddenUI?.includes(HiddenUI.DrawerCloseButton) ? (
                   <CloseDrawerButton header="navigation" />
@@ -66,8 +67,9 @@ export const NavigationHeader: React.FC = () => {
             }
           />
           <Route path="*" element={element || <Box width={28} height={40} />} />
-        </Routes>
-      </HeaderAppBar>
+          </Routes>
+        </HeaderAppBar>
+      )}
     </>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,7 @@ createRoot(document.getElementById("root")!).render(
           },
           blockedCountries: ["AF", "AL"],
           country: "MX",
+          hiddenUI: ['header'],
         }}
       />
     </div>

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -113,6 +113,7 @@ import { ChainType } from '../pages/SelectChainPage/types.js'
     countries = 'countries',
     WalletMenu = 'walletMenu',
     IntegratorStepDetails = 'integratorStepDetails',
+    Header = 'header',
   }
   export type HiddenUIType = `${HiddenUI}`
   


### PR DESCRIPTION
## Description

Optionally hide the header and settings from the config object.

### Where to test

add ` hiddenUI: ['header']` to the widget config. The header should be hidden, except on screens with the back Button.

## Functionality

<img width="433" alt="Screenshot 2025-02-26 at 5 41 53 p m" src="https://github.com/user-attachments/assets/e0cb243b-8cac-49c6-9f71-16c55ace4c98" />
