### PR TITLE
chore(release): 0.1.13-beta.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13-beta.58](https://github.com/bandohq/widget/compare/v0.1.13-beta.57...v0.1.13-beta.58) (2025-04-11)
+
 ### [0.1.13-beta.57](https://github.com/bandohq/widget/compare/v0.1.13-beta.56...v0.1.13-beta.57) (2025-04-10)
 
 ### [0.1.13-beta.56](https://github.com/bandohq/widget/compare/v0.1.13-beta.55...v0.1.13-beta.56) (2025-04-10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.57",
+  "version": "0.1.13-beta.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bandohq/widget",
-      "version": "0.1.13-beta.57",
+      "version": "0.1.13-beta.58",
       "license": "Apache-2.0",
       "dependencies": {
         "@bandohq/contract-abis": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.13-beta.57",
+  "version": "0.1.13-beta.58",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Released a new beta version (0.1.13-beta.58) on April 11, 2025.
	- Updated release information now includes an easy way to compare changes with the previous release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->