### PR TITLE
fix empty subtypes filter on topups

### DIFF
--- a/src/components/SelectProductButton/SelectProductButton.tsx
+++ b/src/components/SelectProductButton/SelectProductButton.tsx
@@ -48,7 +48,11 @@ export const SelectProductButton: React.FC<
 
   const renderAvatar = () =>
     product ? (
-      <Avatar variant="rounded" alt={product.name} src={product.imageUrl} />
+      <Avatar
+        variant="rounded"
+        alt={product.name}
+        src={selectedBrand.imageUrl}
+      />
     ) : (
       <AvatarBadgedDefault />
     );

--- a/src/components/VariantSelector/VariantSelector.tsx
+++ b/src/components/VariantSelector/VariantSelector.tsx
@@ -76,8 +76,10 @@ export const VariantSelector: React.FC<VariantSelectorProps> = ({
           title={brandName}
           image={imageUrl}
           renderItem={(subType) => (
-            <StyledItem onClick={() => handleTopupNavigation(subType)}>
-              {subType}
+            <StyledItem
+              onClick={() => handleTopupNavigation(subType || "Topup")}
+            >
+              {subType || "Topup"}
             </StyledItem>
           )}
         />

--- a/src/utils/variantUtils.ts
+++ b/src/utils/variantUtils.ts
@@ -1,19 +1,48 @@
 import { Variant } from "../stores/ProductProvider/types";
 
 export const getUniqueSubTypes = (variants: Variant[]): string[] => {
-  return Array.from(
-    new Set(variants.flatMap((variant) => variant.subTypes))
-  ).filter((subType): subType is string => typeof subType === "string");
+  const normalizedVariants = variants.map((variant) => {
+    // if subTypes is undefined, null or an empty array, replace it with ["topup"]
+    if (
+      !variant.subTypes ||
+      variant.subTypes.length === 0 ||
+      variant.subTypes.every((subType) => !subType || subType.trim() === "")
+    ) {
+      return { ...variant, subTypes: ["Topup"] };
+    }
+    return variant;
+  });
+
+  const subTypes = Array.from(
+    new Set(normalizedVariants.flatMap((variant) => variant.subTypes || []))
+  );
+
+  // Filtrar y limpiar
+  return subTypes
+    .filter((subType): subType is string => typeof subType === "string")
+    .map((subType) => (subType.trim() === "" ? "Topup" : subType));
 };
 
 export const filterVariantsBySubType = (
   variants: Variant[],
   subType: string
 ): Variant[] => {
-  return subType
-    ? variants.filter((variant) => variant.subTypes.includes(subType))
-    : variants;
+  return variants.filter((variant) => {
+    const normalizedSubTypes =
+      !variant.subTypes ||
+      variant.subTypes.length === 0 ||
+      variant.subTypes.every((sub) => !sub || sub.trim() === "")
+        ? ["Topup"]
+        : variant.subTypes;
+
+    if (subType === "Topup") {
+      return normalizedSubTypes.includes("Topup");
+    }
+
+    return normalizedSubTypes.includes(subType);
+  });
 };
+
 
 export const sortVariantsByPrice = (variants: Variant[]): Variant[] => {
   return variants.sort(

--- a/src/utils/variantUtils.ts
+++ b/src/utils/variantUtils.ts
@@ -1,23 +1,23 @@
 import { Variant } from "../stores/ProductProvider/types";
 
-export const getUniqueSubTypes = (variants: Variant[]): string[] => {
-  const normalizedVariants = variants.map((variant) => {
-    // if subTypes is undefined, null or an empty array, replace it with ["topup"]
-    if (
-      !variant.subTypes ||
-      variant.subTypes.length === 0 ||
-      variant.subTypes.every((subType) => !subType || subType.trim() === "")
-    ) {
-      return { ...variant, subTypes: ["Topup"] };
-    }
-    return variant;
-  });
+// Helper function to normalize subTypes
+const normalizeSubTypes = (subTypes: string[] | undefined): string[] => {
+  if (
+    !subTypes ||
+    subTypes.length === 0 ||
+    subTypes.every((subType) => !subType || subType.trim() === "")
+  ) {
+    return ["Topup"];
+  }
+  return subTypes;
+};
 
+export const getUniqueSubTypes = (variants: Variant[]): string[] => {
   const subTypes = Array.from(
-    new Set(normalizedVariants.flatMap((variant) => variant.subTypes || []))
+    new Set(variants.flatMap((variant) => normalizeSubTypes(variant.subTypes)))
   );
 
-  // Filtrar y limpiar
+  // filter and clean
   return subTypes
     .filter((subType): subType is string => typeof subType === "string")
     .map((subType) => (subType.trim() === "" ? "Topup" : subType));
@@ -28,17 +28,7 @@ export const filterVariantsBySubType = (
   subType: string
 ): Variant[] => {
   return variants.filter((variant) => {
-    const normalizedSubTypes =
-      !variant.subTypes ||
-      variant.subTypes.length === 0 ||
-      variant.subTypes.every((sub) => !sub || sub.trim() === "")
-        ? ["Topup"]
-        : variant.subTypes;
-
-    if (subType === "Topup") {
-      return normalizedSubTypes.includes("Topup");
-    }
-
+    const normalizedSubTypes = normalizeSubTypes(variant.subTypes);
     return normalizedSubTypes.includes(subType);
   });
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/20f8ac94-36da-4e29-8e74-f65a16a6a47f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or empty subtypes for "topup" products, ensuring that "Topup" is displayed and used consistently in the UI and navigation.
  * Enhanced filtering and display logic so that variants without a defined subtype are correctly grouped and shown as "Topup".

* **Refactor**
  * Standardized the way subtypes are processed to provide a more reliable and consistent user experience when selecting or filtering variants.

* **New Features**
  * Updated product avatar display to show the selected brand’s image for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->