### PR TITLE
chore(release): 0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.42](https://github.com/bandohq/widget/compare/v0.1.41...v0.1.42) (2025-08-07)
+
 ### [0.1.41](https://github.com/bandohq/widget/compare/v0.1.40...v0.1.41) (2025-08-05)
 
 ### [0.1.40](https://github.com/bandohq/widget/compare/v0.1.39...v0.1.40) (2025-07-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ### [0.1.42](https://github.com/bandohq/widget/compare/v0.1.41...v0.1.42) (2025-08-07)
+- Fix bug for empty subtypes on topups
 
 ### [0.1.41](https://github.com/bandohq/widget/compare/v0.1.40...v0.1.41) (2025-08-05)
+- Old tx flow cleanup
+- Delete tx flow feature flag
 
 ### [0.1.40](https://github.com/bandohq/widget/compare/v0.1.39...v0.1.40) (2025-07-28)
 Improve quotes ui

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 0.1.42, documenting a bug fix for empty subtypes on topups.

* **Chores**
  * Updated the package version to 0.1.42.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->