### PR TITLE
Chore/world 3 - tx history and recent spends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.44-beta.6](https://github.com/bandohq/widget/compare/v0.1.44-beta.5...v0.1.44-beta.6) (2025-08-14)
+
 ### [0.1.44-beta.5](https://github.com/bandohq/widget/compare/v0.1.44-beta.4...v0.1.44-beta.5) (2025-08-14)
 
 ### [0.1.44-beta.4](https://github.com/bandohq/widget/compare/v0.1.44-beta.3...v0.1.44-beta.4) (2025-08-14)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandohq/widget",
-  "version": "0.1.44-beta.5",
+  "version": "0.1.44-beta.6",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/components/Header/NavigationHeader.tsx
+++ b/src/components/Header/NavigationHeader.tsx
@@ -17,6 +17,7 @@ import { SettingsButton, HistoryButton } from "./SettingsButton";
 import { SplitWalletMenuButton } from "./WalletHeader";
 import { useProduct } from "../../stores/ProductProvider/ProductProvider";
 import { useAccount } from "@lifi/wallet-management";
+import { useWorld } from "../../hooks/useWorld.js";
 
 export const NavigationHeader: React.FC = () => {
   const { subvariant, hiddenUI, variant } = useWidgetConfig();
@@ -26,6 +27,7 @@ export const NavigationHeader: React.FC = () => {
   const { element, title } = useHeaderStore((state) => state);
   const { pathname } = useLocation();
   const { account } = useAccount();
+  const { isWorld } = useWorld();
 
   const cleanedPathname = pathname.endsWith("/")
     ? pathname.slice(0, -1)
@@ -82,7 +84,7 @@ export const NavigationHeader: React.FC = () => {
               path={navigationRoutes.home}
               element={
                 <HeaderControlsContainer>
-                  {account.address && <HistoryButton />}
+                  {(account.address || isWorld) && <HistoryButton />}
                   {!hiddenUI?.includes(HiddenUI.Header) && <SettingsButton />}
                   {variant === "drawer" &&
                   !hiddenUI?.includes(HiddenUI.DrawerCloseButton) ? (

--- a/src/components/RecentSpends/RecentSpends.tsx
+++ b/src/components/RecentSpends/RecentSpends.tsx
@@ -3,22 +3,30 @@ import { ClockCounterClockwise } from "@phosphor-icons/react";
 import { HorizontalSlider, Transaction } from "./HorizontalSlider";
 import { useFetch } from "../../hooks/useFetch";
 import { useAccount } from "@lifi/wallet-management";
+import { useWorld } from "../../hooks/useWorld.js";
 
 export const RecentSpends = () => {
   const { account } = useAccount();
+  const { isWorld, provider } = useWorld();
+
+  const userAddress = isWorld
+    ? provider?.user?.walletAddress
+    : account?.address;
+  const chainId = isWorld ? 480 : account?.chainId;
+
   const {
     data: transactions,
     isPending,
     error,
   } = useFetch<{ transactions: Transaction[] }>({
-    url: account.address ? `wallets/${account.address}/transactions` : "",
+    url: userAddress ? `wallets/${userAddress}/transactions` : "",
     method: "GET",
     queryOptions: {
-      queryKey: ["transactions", account.address, account.chainId],
-      enabled: !!account.address && !!account.chainId,
+      queryKey: ["transactions", userAddress, chainId],
+      enabled: !!userAddress && !!chainId,
     },
     queryParams: {
-      chainId: account.chainId,
+      chainId,
     },
   });
 
@@ -29,7 +37,7 @@ export const RecentSpends = () => {
         ).values()
       )
     : [];
-  if (!account.address || !uniqueBrandTransactions.length || error) return null;
+  if (!userAddress || !uniqueBrandTransactions.length || error) return null;
   return (
     <div style={{ display: "flex" }}>
       <div style={{ display: "flex", alignItems: "center", width: "100%" }}>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,4 +2,4 @@ export const defaultMaxHeight = 686;
 
 export const bandoExplorerUrl = "https://bando.cool";
 
-export const BANDO_API_URL = "https://apidev.bando.cool/api/v1/";
+export const BANDO_API_URL = "https://api.bando.cool/api/v1/";

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -2,4 +2,4 @@ export const defaultMaxHeight = 686;
 
 export const bandoExplorerUrl = "https://bando.cool";
 
-export const BANDO_API_URL = "https://api.bando.cool/api/v1/";
+export const BANDO_API_URL = "https://apidev.bando.cool/api/v1/";

--- a/src/pages/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory/TransactionHistory.tsx
@@ -8,6 +8,7 @@ import { List } from "@mui/material";
 import { TokenListItemSkeleton } from "../../components/TokenList/TokenListItem";
 import { Box } from "@mui/system";
 import { NoTransactionsFound } from "./NoTransactionsFound";
+import { useWorld } from "../../hooks/useWorld.js";
 
 export interface Transaction {
   id: string;
@@ -32,19 +33,25 @@ export const TransactionsHistoryPage = () => {
   const { t } = useTranslation();
   useHeader(t("history.title"));
   const { account } = useAccount();
+  const { isWorld, provider } = useWorld();
+
+  const userAddress = isWorld
+    ? provider?.user?.walletAddress
+    : account?.address;
+  const chainId = isWorld ? 480 : account?.chainId;
 
   const {
     data: transactions,
     isPending,
     error,
   } = useFetch({
-    url: account.address ? `wallets/${account.address}/transactions` : "",
+    url: userAddress ? `wallets/${userAddress}/transactions` : "",
     method: "GET",
     queryOptions: {
-      queryKey: ["transactions", account.address, account.chainId],
+      queryKey: ["transactions", userAddress, chainId],
     },
     queryParams: {
-      chainId: account.chainId,
+      chainId,
     },
   });
 


### PR DESCRIPTION
Work done
- tx history button
- tx history query
- recent spends bar
- 
![WhatsApp Image 2025-08-14 at 00 32 15 (1)](https://github.com/user-attachments/assets/d22ace7d-2499-4a3c-8263-a17003f5775b)
![WhatsApp Image 2025-08-14 at 00 32 15 (2)](https://github.com/user-attachments/assets/e6f8b7ff-1287-4c74-93ea-1c7913b4fbb8)
![WhatsApp Image 2025-08-14 at 00 32 15](https://github.com/user-attachments/assets/9c6aba24-298e-4aa5-a561-df2fbe31acf2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable Recent Spends and Transaction History in World mode, using the world wallet address and chain.
  * Show the History button on Home in World mode, even without a connected wallet.

* **Documentation**
  * Added changelog entry for version 0.1.44-beta.6.

* **Chores**
  * Bumped version to 0.1.44-beta.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->