### PR TITLE
switch product reset to product page

### DIFF
--- a/src/components/Header/NavigationHeader.tsx
+++ b/src/components/Header/NavigationHeader.tsx
@@ -47,9 +47,6 @@ export const NavigationHeader: React.FC = () => {
     if (isBackToHome) {
       navigate(navigationRoutes.home);
     } else {
-      if (basePath === navigationRoutes.form.replace(/^\//, "")) {
-        updateProduct(null);
-      }
       navigateBack();
     }
   };

--- a/src/pages/ProductsPage/ProductsPage.tsx
+++ b/src/pages/ProductsPage/ProductsPage.tsx
@@ -34,6 +34,7 @@ export const ProductsPage = () => {
 
   useEffect(() => {
     setFieldValue("reference", "");
+    updateProduct(null);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigating back from forms no longer unexpectedly clears the selected product; selection now persists as users return.
  * Opening the Products page now resets any previously selected product, preventing stale selections and ensuring a clean starting state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->